### PR TITLE
Fix indentation when inserting new task and smartindent is on

### DIFF
--- a/ftplugin/tasks.vim
+++ b/ftplugin/tasks.vim
@@ -261,16 +261,21 @@ function! s:NewTask(direction)
     return
   endif
 
-  let l:indendation = matchlist(l:project['line'], s:regProject)[1]
+  let l:indentation = matchlist(l:project['line'], s:regProject)[1]
   let l:text = g:TasksMarkerBase . ' '
 
+  let l:smartindent = &smartindent
+  setlocal nosmartindent
+
   if a:direction == -1
-    exec 'normal O' . l:indendation . l:text
+    exec 'normal O' . l:indentation . l:text
   else
-    exec 'normal o' . l:indendation . l:text
+    exec 'normal o' . l:indentation . l:text
   endif
 
   exec 'normal >>'
+
+  let &smartindent = l:smartindent
 
   startinsert!
 endfunc


### PR DESCRIPTION
vim-tasks' behavior when inserting a new task depends on whether `smartindent` is on (`autoindent` doesn't seem to have any effect though, which seemed odd to me). This will temporarily disable `smartindent` in the current buffer if necessary, then reset it after inserting the new task.

This fixes the second part of issue #13. I also fixed the spelling of a variable name.